### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[severino42/python-http-quickstart](https://github.com/severino42/python-http-quickstart.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[severino42/python-http-hpmb](https://github.com/severino42/python-http-hpmb.git) |  | []() | 
+[severino42/python-http-app](https://github.com/severino42/python-http-app.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[severino42/python-http-test](https://github.com/severino42/python-http-test.git) |  | []() | 
+[severino42/python-http-hpmb](https://github.com/severino42/python-http-hpmb.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[severino42/python-http-quickstart](https://github.com/severino42/python-http-quickstart.git) |  | []() | 
+[severino42/python-http-hpmb](https://github.com/severino42/python-http-hpmb.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[severino42/python-http-hpmb](https://github.com/severino42/python-http-hpmb.git) |  | []() | 
+[severino42/python-http-test](https://github.com/severino42/python-http-test.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: severino42
+  repo: python-http-quickstart
+  url: https://github.com/severino42/python-http-quickstart.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: severino42
-  repo: python-http-hpmb
-  url: https://github.com/severino42/python-http-hpmb.git
+  repo: python-http-test
+  url: https://github.com/severino42/python-http-test.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: severino42
-  repo: python-http-test
-  url: https://github.com/severino42/python-http-test.git
+  repo: python-http-hpmb
+  url: https://github.com/severino42/python-http-hpmb.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: severino42
-  repo: python-http-quickstart
-  url: https://github.com/severino42/python-http-quickstart.git
+  repo: python-http-hpmb
+  url: https://github.com/severino42/python-http-hpmb.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: severino42
-  repo: python-http-hpmb
-  url: https://github.com/severino42/python-http-hpmb.git
+  repo: python-http-app
+  url: https://github.com/severino42/python-http-app.git
   version: ""
   versionURL: ""

--- a/repositories/templates/severino42-python-http-app-sr.yaml
+++ b/repositories/templates/severino42-python-http-app-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "1"
   creationTimestamp: null
   labels:
     owner: severino42

--- a/repositories/templates/severino42-python-http-app-sr.yaml
+++ b/repositories/templates/severino42-python-http-app-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: severino42
+    provider: github
+    repository: python-http-app
+  name: severino42-python-http-app
+spec:
+  description: Imported application for severino42/python-http-app
+  httpCloneURL: https://github.com/severino42/python-http-app.git
+  org: severino42
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: python-http-app
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/severino42/python-http-app.git

--- a/repositories/templates/severino42-python-http-app-sr.yaml
+++ b/repositories/templates/severino42-python-http-app-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "1"
+    jenkins.io/last-build-number-for-master: "2"
   creationTimestamp: null
   labels:
     owner: severino42

--- a/repositories/templates/severino42-python-http-hpmb-sr.yaml
+++ b/repositories/templates/severino42-python-http-hpmb-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "1"
   creationTimestamp: null
   labels:
     owner: severino42

--- a/repositories/templates/severino42-python-http-hpmb-sr.yaml
+++ b/repositories/templates/severino42-python-http-hpmb-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: severino42
+    provider: github
+    repository: python-http-hpmb
+  name: severino42-python-http-hpmb
+spec:
+  description: Imported application for severino42/python-http-hpmb
+  httpCloneURL: https://github.com/severino42/python-http-hpmb.git
+  org: severino42
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: python-http-hpmb
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/severino42/python-http-hpmb.git

--- a/repositories/templates/severino42-python-http-quickstart-sr.yaml
+++ b/repositories/templates/severino42-python-http-quickstart-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: severino42
+    provider: github
+    repository: python-http-quickstart
+  name: severino42-python-http-quickstart
+spec:
+  description: Imported application for severino42/python-http-quickstart
+  httpCloneURL: https://github.com/severino42/python-http-quickstart.git
+  org: severino42
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: python-http-quickstart
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/severino42/python-http-quickstart.git

--- a/repositories/templates/severino42-python-http-test-sr.yaml
+++ b/repositories/templates/severino42-python-http-test-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: severino42
+    provider: github
+    repository: python-http-test
+  name: severino42-python-http-test
+spec:
+  description: Imported application for severino42/python-http-test
+  httpCloneURL: https://github.com/severino42/python-http-test.git
+  org: severino42
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: python-http-test
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/severino42/python-http-test.git


### PR DESCRIPTION
Update [severino42/python-http-app](https://github.com/severino42/python-http-app.git) 

Command run was `jx create quickstart`
<hr />

Update [severino42/python-http-app](https://github.com/severino42/python-http-app.git) 

Command run was `jx create quickstart`
<hr />

Update [severino42/python-http-app](https://github.com/severino42/python-http-app.git) 

Command run was `jx create quickstart`
<hr />

Update [severino42/python-http-hpmb](https://github.com/severino42/python-http-hpmb.git) 

Command run was `jx create quickstart`
<hr />

Update [severino42/python-http-test](https://github.com/severino42/python-http-test.git) 

Command run was `jx create quickstart`
<hr />

Update [severino42/python-http-hpmb](https://github.com/severino42/python-http-hpmb.git) 

Command run was `jx create quickstart`
<hr />

Update [severino42/python-http-quickstart](https://github.com/severino42/python-http-quickstart.git) 

Command run was `jx create quickstart`